### PR TITLE
Decouples authentication logic from AppShell

### DIFF
--- a/FrostByte.App/AppShell.cs
+++ b/FrostByte.App/AppShell.cs
@@ -24,9 +24,23 @@ public partial class AppShell : Shell
 
         // Subscribe to the authentication required event
         _vm.AuthenticationRequired += OnAuthenticationRequired;
-        Task.Run(async () => await _vm.CheckAuthenticationAsync());
+        // Removed fire-and-forget authentication check. Use InitializeAsync after construction.
     }
 
+    /// <summary>
+    /// Performs initial authentication check. Call this after constructing AppShell.
+    /// </summary>
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            await _vm.CheckAuthenticationAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed during initial authentication check.");
+        }
+    }
     private void AddPageToShell(Func<Page> pageFactory, string route, bool navBarVisible)
     {
         var shellContent = new ShellContent

--- a/FrostByte.App/AppShell.cs
+++ b/FrostByte.App/AppShell.cs
@@ -1,18 +1,21 @@
 ﻿using FrostByte.Presentation.ViewModels;
 using FrostByte.Presentation.Views;
+using Microsoft.Extensions.Logging;
 
 namespace FrostByte.App;
 
 public partial class AppShell : Shell
 {
     private readonly Func<Page> _authPageFactory;
+    private readonly ILogger<AppShell> _logger;
     private readonly AppShellVm _vm;
 
     public AppShell(Func<CalendarPage> calendarPageFactory, Func<DayPage> dayPageFactory,
-        Func<AuthPage> authPageFactory, AppShellVm vm)
+        Func<AuthPage> authPageFactory, AppShellVm vm, ILogger<AppShell> logger)
     {
         _vm = vm ?? throw new ArgumentNullException(nameof(vm));
         _authPageFactory = authPageFactory ?? throw new ArgumentNullException(nameof(authPageFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         FlyoutIsPresented = false;
         FlyoutBehavior = FlyoutBehavior.Disabled;
@@ -21,7 +24,7 @@ public partial class AppShell : Shell
 
         // Subscribe to the authentication required event
         _vm.AuthenticationRequired += OnAuthenticationRequired;
-        _ = _vm.CheckAuthenticationAsync();
+        Task.Run(async () => await _vm.CheckAuthenticationAsync());
     }
 
     private void AddPageToShell(Func<Page> pageFactory, string route, bool navBarVisible)
@@ -38,6 +41,13 @@ public partial class AppShell : Shell
 
     private async void OnAuthenticationRequired(object? sender, EventArgs e)
     {
-        await Navigation.PushModalAsync(_authPageFactory());
+        try
+        {
+            await Navigation.PushModalAsync(_authPageFactory());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to navigate to authentication page.");
+        }
     }
 }

--- a/FrostByte.App/AppShell.cs
+++ b/FrostByte.App/AppShell.cs
@@ -53,7 +53,13 @@ public partial class AppShell : Shell
         Items.Add(shellContent);
     }
 
-    private async void OnAuthenticationRequired(object? sender, EventArgs e)
+    private void OnAuthenticationRequired(object? sender, EventArgs e)
+    {
+        // Fire-and-forget async work, log exceptions
+        _ = HandleAuthenticationRequiredAsync();
+    }
+
+    private async Task HandleAuthenticationRequiredAsync()
     {
         try
         {

--- a/FrostByte.Presentation/ViewModels/AppShellVm.cs
+++ b/FrostByte.Presentation/ViewModels/AppShellVm.cs
@@ -1,0 +1,30 @@
+﻿using FrostByte.Application.Services;
+
+namespace FrostByte.Presentation.ViewModels;
+
+/// <summary>
+///     View model for the application shell. It encapsulates authentication
+///     checks so that the UI does not directly depend on service implementations.
+///     When authentication is required, the <see cref="AuthenticationRequired" />
+///     event will be raised.
+/// </summary>
+public class AppShellVm(IAuthService authService)
+{
+    private readonly IAuthService _authService = authService;
+
+    /// <summary>
+    ///     Raised when the user is not authenticated and the UI should present
+    ///     an authentication page.
+    /// </summary>
+    public event EventHandler? AuthenticationRequired;
+
+    /// <summary>
+    ///     Checks whether the user is authenticated. If not, the
+    ///     <see cref="AuthenticationRequired" /> event is raised.
+    /// </summary>
+    public async Task CheckAuthenticationAsync()
+    {
+        var isAuthenticated = await _authService.IsAuthenticatedAsync();
+        if (!isAuthenticated) AuthenticationRequired?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/FrostByte.Presentation/ViewModels/AppShellVm.cs
+++ b/FrostByte.Presentation/ViewModels/AppShellVm.cs
@@ -10,8 +10,6 @@ namespace FrostByte.Presentation.ViewModels;
 /// </summary>
 public class AppShellVm(IAuthService authService)
 {
-    private readonly IAuthService _authService = authService;
-
     /// <summary>
     ///     Raised when the user is not authenticated and the UI should present
     ///     an authentication page.
@@ -24,7 +22,7 @@ public class AppShellVm(IAuthService authService)
     /// </summary>
     public async Task CheckAuthenticationAsync()
     {
-        var isAuthenticated = await _authService.IsAuthenticatedAsync();
+        var isAuthenticated = await authService.IsAuthenticatedAsync();
         if (!isAuthenticated) AuthenticationRequired?.Invoke(this, EventArgs.Empty);
     }
 }


### PR DESCRIPTION
Moves authentication logic into a dedicated AppShellVm,
abstracting away direct dependency on authentication
service implementations within the UI layer.

This enables better separation of concerns and makes the
AppShell more testable and maintainable. It introduces an
AuthenticationRequired event that gets raised to present
the AuthPage modally when the user is not authenticated.
